### PR TITLE
Fix missing salt in jetton wallet config

### DIFF
--- a/scripts/claimApi.ts
+++ b/scripts/claimApi.ts
@@ -138,6 +138,8 @@ app.get('/wallet/:address', (req: Request, res: Response) => {
     let jettonWalletContract = JettonWallet.createFromConfig({ownerAddress: owner,
                                                       jettonMasterAddress: minter,
                                                       merkleRoot: merkleRoot,
+                                                      // we can pass arbitrary salt here bc it won't affect address calculation and payload
+                                                      salt: 1n,
     }, wallet_code);
 
     let stateInitB = beginCell();

--- a/scripts/generateTestJetton.ts
+++ b/scripts/generateTestJetton.ts
@@ -198,9 +198,13 @@ export async function run(provider: NetworkProvider) {
     console.log("Wallet address: ", wallet.address.toString());
 
     //now lets create jetton wallet owned by wallet
+    // get salt from minter for correct init state
+    const jettonWalletSalt = await minter.getWalletSalt(wallet.address);
+
     let jettonWalletContract = JettonWallet.createFromConfig({ownerAddress: wallet.address,
                                                       jettonMasterAddress: minter.address,
                                                       merkleRoot: merkleRoot,
+                                                      salt: jettonWalletSalt,
     }, wallet_code);
     let jettonWallet = provider.open(jettonWalletContract);
 


### PR DESCRIPTION
Currently both of `claimApi.ts` and `generateTestJetton.ts` couldn't be compiled or ran because of incorrect jetton wallet config params passing and creation. This commit fixes this without any wrapper API changes